### PR TITLE
Additional README Suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 This repository contains code that might help us develop an artificial general intelligence - one day!
 
+## Table of Contents
+
+* [Introduction](#introduction)
+* [This Repository](#this-repository)
+* [Code Structure](#code-structure)
+* [Important Notes](#important-notes)
+* [Getting Started](#getting-started)
+    * [Supported Operating Systems](#supported-operating-systems)
+    * [Installation Instructions](#installation-instructions)
+    * [Running Basic](#running-basic)
+    * [Run a Demo](#run-a-demo)
+    * [Run Generic Experiments](#run-generic-experiments)
+    * [Run Advanced Experiments](#run-advanced-experiments)
+    * [Running the GUI](#running-the-gui)
+* [Resources](#resources)
+
 ## Introduction
 For an introduction to the content and purpose of this repository, see the [Wiki](https://github.com/ProjectAGI/agi/wiki). Motivation, results, ideas and other natural language stuff is on our [website](https://agi.io) and in particular our [blog](https://blog.agi.io).
 
@@ -15,7 +31,7 @@ The code includes a simple graphical UI, an interprocess layer for distributed c
 
 We also include implementations of many algorithms from the AI and ML literature.
 
-## Code structure
+## Code Structure
 
 This repository consists of:
 
@@ -27,7 +43,7 @@ This repository consists of:
 Compute nodes have a RESTful API, so it is possible to implement components in other languages, or write alternative visualisations.
 **The API is documented at ```/doc/API/http.swagger.yaml```**
 
-# Important notes
+## Important Notes
 
 * The framework supports a distributed graph of compute nodes.
 
@@ -51,7 +67,7 @@ Compute nodes have a RESTful API, so it is possible to implement components in o
 
 * The code can be executed on a single local computer in an IDE, or on remote cloud instances.
 
-# Getting Started
+## Getting Started
 
 The repository contains scripts to help with installation, setup and running.
 
@@ -62,15 +78,14 @@ All scripts utilise environmental variables defined in a 'variables' file. Every
 
 That is necessary even if you are using the `run-in-docker.sh` script.
 
-## Supported Operating Systems
+### Supported Operating Systems
 
 - Linux 
 - Mac OS X
 
 We aim to support Microsoft Windows in future. However, it requires a custom build of the database HTTP API.
 
-
-## Installation Instructions
+### Installation Instructions
 
 The following instructions apply to setting up a development environment. As mentioned above, if you wish to simply run experiments, you only need to install Docker and use the `run-in-docker.sh` script. For a dev environment, it can be convenient to use Docker as well.
 
@@ -97,16 +112,15 @@ Then:
 * Set variables. Duplicate `/resources/variables-template.sh`, and overwrite with values suitable for your environment. Copy it to a convenient location and set an environmental variable VARIABLES_FILE to point to it using the full path. We recommend you set that up in `.bashrc` so that it is always defined correctly.
 * The favoured (and our current) approach is to use 'in memory' persistence, specified in `node.properties` in the working folder. However, postgres is an option. If using postgres, setup and run the db by executing `/bin/db/setup.sh`
 
-## Running Basic
+### Running Basic
 * The folder that you are running from must contain the file `node.properties` and a log4j configuration file. A working template is given in `/resources/run-empty`.
 * `node.properties` allows you to set the db mode between 'jdbc' and 'node'. The former is PostgreSQL, the latter is 'in-memory'.
 * You can build and run the Compute Node using the scripts in `/bin/node_coordinator`. There is also the option of doing this in a docker container using `/bin/run-in-docker.sh`, read the help to see how to use it.
 * There scripts for running the system, they take parameters such as the node properties and the initial state of system (entities, data)
 * Once a Compute Node is run as a Demo or Generic Experiment (see below), it will be running as a server. You can then load and export experiments via the HTTP API. The GUI utilises the API to make it easy to do that and to visualise all data structures, entity tree and entity configurations.
 
-
-## Run a Demo
-The simplest way to run an experiment is to choose a Demo. There are a bunch of examples in the package `io.agi.framework.demo`. 
+### Run a Demo
+The simplest way to run an experiment is to choose a Demo. There are a bunch of examples in the package `io.agi.framework.demo`.
 
 * Choose a demo. By convention they are named `[demo-name]Demo`.
 * Launch a Compute Node by running the appropriate `main()` method for that Demo. 
@@ -114,8 +128,7 @@ The simplest way to run an experiment is to choose a Demo. There are a bunch of 
 * Send an `update` signal to the root `Experiment` node to start the experiment. You can do this using the RESTful API, or with the GUI, where you can also see what's going on. 
 * The Demo is an experiment that has been defined in code, alternatively, you can run an experiment defined in JSON input files.
 
-
-## Run a Generic Experiment
+### Run Generic Experiments
 This describes how to run an experiment defined in JSON input files. If you don't already have them ready to go, you can run a given demo and export the input files (using GUI or RESTful API).
 
 * Launch the framework with the generic `main()` method
@@ -124,18 +137,15 @@ This describes how to run an experiment defined in JSON input files. If you don'
 * It could be specified as input parameter when running, or after launched you can use the RESTful API or GUI
 * As above, get the experiment started by sending an `update` to the root `Experiment` node
 
-
-## Run Advanced Experiments
+### Run Advanced Experiments
 We have a tool called [run-framework](https://github.com/ProjectAGI/run-framework) which makes it easy to run predefined experiments, locally or remotely on physical or AWS infrastructure, conduct parameter sweeps, export and upload the results and more.
 
 There is also a set of experiment folders already defined and ready to go at [experiment-definitions](https://github.com/ProjectAGI/experiment-definitions).
 
-
-## Running GUI
+### Running the GUI
 * Run GUI by running the web server `/bin/www/python_server.sh` and going to [http://localhost:8000](http://localhost:8000)
 * Alternatively, open any of the web pages in `/code/wwww`
 * Start with `index.html`
-
 
 ## Resources
 Have a look in the `/resources` folder for useful .... resources!


### PR DESCRIPTION
Just wanted to get some feedback first on my initial thoughts/suggestions for improving the README. The aim is to make the README more straightforward and get users/contributors up and running quickly. Leaving the wiki with the bulk of information and possibly a `/docs` directory that I will talk about here.

## Suggestions 
- Getting Started should be the first thing in the README
- Consolidate Intro, This repository into the first paragraph under the main title
- Eliminate Important Notes, some of it is already in the wiki.
- Short "Contributing" section at the bottom, linking to `CONTRIBUTING.md` which would contain specific contributing guidelines e.g. mentioning conduct, coding styles, etc.
- Fix up the flow of "Getting Started", possibly split parts of Installation Instructions into "Pre-requisites" section or something. Make the instructions as simple and straight forward as possible
- Resources and Running sections are OK where they are for now, going below Getting Started
- Consolidate the `notes` and `doc` into a single `/docs` directory. A common practice I'm used to is also include some technical docs like that in the repository, leaving the wiki with more about "how things work".

## Information for Users

### Contributing 
A person who wants to contribute to the project would be likely look for a specific section in the README about contributing which would then link to a `CONTRIBUTING.md` - a common practice, where they can can see instructions/guidelines about the process. This can include mentions about code style, versioning, approval process, dependencies, updating the documentation and anything else we'd like the contributor to know. Would also consider this for other repositories that are open for contribution.

It may also be useful to utilise the [GitHub Templates](https://github.com/blog/2111-issue-and-pull-request-templates) for pull requests and issues.

### Running Demos/Experiments
A person who wants to run and replicate our experiments by using `experiment-definitions` or run existing demos should be OK with the current instructions. The instructions are clear on what to do, but not necessarily what is "happening" which would then require further reading in the wiki. Not sure what the best way of handling this, possibly linking directly to a wiki page in those sections as an FYI.

### Writing Demos/Algorithms
A person who wants to write their own demos or algorithms may struggle due to the lack of instructions available. Would just need to dig around the code and replicate it. It would be useful to provide more details about that. I don't think it would fit in with the objective of the README, so would likely place this in a `/docs` directory.
