### PR TITLE
Fix Folder Permissions + folderPath validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ target/
 
 # intellij files
 workspace.xml
+
+# vscode
+.classpath
+.project
+.settings

--- a/code/core/src/io/agi/framework/coordination/http/HttpExportHandler.java
+++ b/code/core/src/io/agi/framework/coordination/http/HttpExportHandler.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -81,13 +82,16 @@ public class HttpExportHandler implements HttpHandler {
                         if( m.containsKey( PARAMETER_EXPORT_LOCATION ) ) {
                             String folderPath = m.get( PARAMETER_EXPORT_LOCATION ).trim(); // essential
 
-                            // make sure that the created files are writeable by others
-                            File file = new File( folderPath );
-                            file.setWritable( true, false );
-
+                            File folder = new File( folderPath );
                             Path filepath = Paths.get( folderPath, filename );
 
-                            // todo check that path is valid
+                            // check if folder path exists
+                            if( ! folder.exists()) {
+                                throw new FileNotFoundException("Could not find export folder: " + folderPath);
+                            }
+
+                            // make sure that the export folder is writable by others
+                            folder.setWritable( true, false );
 
                             boolean success = Framework.SaveSubtree( entityName, type, filepath.toString() );
 

--- a/code/core/src/io/agi/framework/coordination/http/HttpExportHandler.java
+++ b/code/core/src/io/agi/framework/coordination/http/HttpExportHandler.java
@@ -81,6 +81,10 @@ public class HttpExportHandler implements HttpHandler {
                         if( m.containsKey( PARAMETER_EXPORT_LOCATION ) ) {
                             String folderPath = m.get( PARAMETER_EXPORT_LOCATION ).trim(); // essential
 
+                            // make sure that the created files are writeable by others
+                            File file = new File( folderPath );
+                            file.setWritable( true, false );
+
                             Path filepath = Paths.get( folderPath, filename );
 
                             // todo check that path is valid


### PR DESCRIPTION
I went back through the commits and found that the `setWritable` on the prefix folder was removed in this [commit](https://github.com/ProjectAGI/agi/commit/23ae48d334a2fc4955113bcdf55f0c436f095aa0#diff-b211744e79da03094d38f5e607e7eceeL83) for some reason.

I re-added this so it's writable again and also added a check to ensure the folderPath is valid.