### PR TITLE
Fix Classification Accuracy in Tests

### DIFF
--- a/code/core/pom.xml
+++ b/code/core/pom.xml
@@ -24,7 +24,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.agi.core</groupId>
     <artifactId>agief</artifactId>
-    <version>1.0.167(36d02fd)</version>
+    <version>1.0.168(b9180c6)</version>
     <name>agief</name>
 
     <properties>

--- a/code/core/src/main/java/io/agi/core/data/FloatArray.java
+++ b/code/core/src/main/java/io/agi/core/data/FloatArray.java
@@ -1341,6 +1341,21 @@ public class FloatArray {
         }
     }
 
+    public void equals( FloatArray v ) {
+
+        int offset = 0;
+
+        while( offset < _values.length ) {
+            if ( _values[ offset ] == v._values[ offset ] ) {
+                _values[ offset ] = 1.0f;    // set to 'True'
+            }
+            else {
+                _values[ offset ] = 0.0f;   // set to 'False'
+            }
+            ++offset;
+        }
+    }
+
     public void add( FloatArray v ) {
 
         int offset = 0;

--- a/code/core/src/test/java/io/agi/core/ml/supervised/LogisticRegressionTest.java
+++ b/code/core/src/test/java/io/agi/core/ml/supervised/LogisticRegressionTest.java
@@ -188,7 +188,6 @@ public class LogisticRegressionTest {
             System.out.println( error );
         }
 
-
         // total correct values / total values
         double trainAccuracy = _predictionsVector.mean();
         double testAccuracy = _predictionsVectorTest.mean();

--- a/code/core/src/test/java/io/agi/core/ml/supervised/LogisticRegressionTest.java
+++ b/code/core/src/test/java/io/agi/core/ml/supervised/LogisticRegressionTest.java
@@ -51,11 +51,13 @@ public class LogisticRegressionTest {
     private Data _classTruthVectorTest = null;
 
     // Parameters
-    private String trainPath;
-    private String testPath;
-    private int featuresIdxMin;
-    private int featuresIdxMax;
-    private int classTruthIdx;
+    private String _trainPath;
+    private String _testPath;
+    private int _featuresIdxMin;
+    private int _featuresIdxMax;
+    private int _classTruthIdx;
+    private double _trainAccuracy;
+    private double _testAccuracy;
 
     /**
      * Sets up the parameters for the test
@@ -65,13 +67,17 @@ public class LogisticRegressionTest {
      * @param featuresIdxMin The column ID where features start
      * @param featuresIdxMax The column ID where features end
      * @param classTruthIdx The column ID of the target (y) / class truth
+     * @param trainAccuracy The expected training accuracy for assertion
+     * @param testAccuracy The expected test accuracy for assertion
      */
-    public LogisticRegressionTest(String trainPath, String testPath, int featuresIdxMin, int featuresIdxMax, int classTruthIdx) {
-        this.trainPath = trainPath;
-        this.testPath = testPath;
-        this.featuresIdxMin = featuresIdxMin;
-        this.featuresIdxMax = featuresIdxMax;
-        this.classTruthIdx = classTruthIdx;
+    public LogisticRegressionTest(String trainPath, String testPath, int featuresIdxMin, int featuresIdxMax, int classTruthIdx, double trainAccuracy, double testAccuracy) {
+        this._trainPath = trainPath;
+        this._testPath = testPath;
+        this._featuresIdxMin = featuresIdxMin;
+        this._featuresIdxMax = featuresIdxMax;
+        this._classTruthIdx = classTruthIdx;
+        this._trainAccuracy = trainAccuracy;
+        this._testAccuracy = testAccuracy;
     }
 
     /**
@@ -82,9 +88,10 @@ public class LogisticRegressionTest {
     @Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                {"iris.train.csv", "iris.test.csv", 0, 3, 4},
-                {"spectf.train.csv", "spectf.test.csv", 1, 44, 0},
-                {"skin.train.sample.csv", "skin.test.sample.csv", 0, 2, 3}
+                // trainPath, testPath, featuresIdxMin, featuresIdxMax, classTruthIdx, trainAccuracy, testAccuracy
+                {"iris.train.csv", "iris.test.csv", 0, 3, 4, 0.99, 0.95},
+                {"spectf.train.csv", "spectf.test.csv", 1, 44, 0, 1, 0.59},
+                {"skin.train.sample.csv", "skin.test.sample.csv", 0, 2, 3, 0.92, 0.92}
         });
     }
 
@@ -113,13 +120,13 @@ public class LogisticRegressionTest {
     public void setUp() throws Exception {
 
         // get data from file
-        String filePath = "src/test/resources/" + trainPath;
-        _featuresMatrixTrain = Data2d.createFromCSV( filePath, featuresIdxMin, featuresIdxMax);
-        _classTruthVector = Data2d.createFromCSV( filePath, classTruthIdx, classTruthIdx );
+        String filePath = "src/test/resources/" + _trainPath;
+        _featuresMatrixTrain = Data2d.createFromCSV( filePath, _featuresIdxMin, _featuresIdxMax);
+        _classTruthVector = Data2d.createFromCSV( filePath, _classTruthIdx, _classTruthIdx );
 
-        filePath = "src/test/resources/" + testPath;
-        _featuresMatrixTest = Data2d.createFromCSV( filePath, featuresIdxMin, featuresIdxMax );
-        _classTruthVectorTest = Data2d.createFromCSV( filePath, classTruthIdx, classTruthIdx );
+        filePath = "src/test/resources/" + _testPath;
+        _featuresMatrixTest = Data2d.createFromCSV( filePath, _featuresIdxMin, _featuresIdxMax );
+        _classTruthVectorTest = Data2d.createFromCSV( filePath, _classTruthIdx, _classTruthIdx );
 
         _predictionsVector = new Data( _classTruthVector._dataSize );
         _predictionsVectorTest = new Data( _classTruthVectorTest._dataSize );
@@ -148,7 +155,6 @@ public class LogisticRegressionTest {
     private void predict() throws Exception {
 
         boolean log = false;
-        float _eps = 0.0000001f;
 
         // Evaluate on training data
         _learner.predict( _featuresMatrixTrain, _predictionsVector );
@@ -158,9 +164,9 @@ public class LogisticRegressionTest {
 
         if ( log )
         {
-            String features = Data2d.toString( _featuresMatrixTrain );
+            String features = Data2d.toString( _featuresMatrixTest );
             String predictions = Data2d.toString( _predictionsVectorTest );
-            String classTruth = Data2d.toString( _classTruthVector );
+            String classTruth = Data2d.toString( _classTruthVectorTest );
 
             System.out.println( "Features" );
             System.out.println( features );
@@ -172,9 +178,9 @@ public class LogisticRegressionTest {
             System.out.println( classTruth );
         }
 
-        // set values to 1 if error, 0 if not
-        _predictionsVector.approxEquals( _classTruthVector, _eps );
-        _predictionsVectorTest.approxEquals( _classTruthVectorTest, _eps );
+        // set values to 1 if correct, 0 if not
+        _predictionsVector.equals( _classTruthVector );
+        _predictionsVectorTest.equals( _classTruthVectorTest );
 
         if ( log ) {
             String error = Data2d.toString( _predictionsVectorTest );
@@ -183,16 +189,16 @@ public class LogisticRegressionTest {
         }
 
 
-        // count how many errors - an error is where the diff between prediction and label is greater than eps
-        double trainMeanError = _predictionsVector.mean();
-        double testMeanError = _predictionsVectorTest.mean();
+        // total correct values / total values
+        double trainAccuracy = _predictionsVector.mean();
+        double testAccuracy = _predictionsVectorTest.mean();
 
         System.out.println( "Model = " + _learner.getModelString() );
-        System.out.println( "Training Accuracy = " + trainMeanError * 100 + "%" );
-        System.out.println( "Testing Accuracy = " + testMeanError * 100 + "%" );
+        System.out.println( "Training Accuracy = " + trainAccuracy * 100 + "%" );
+        System.out.println( "Testing Accuracy = " + testAccuracy * 100 + "%" );
 
-        assertTrue( trainMeanError > 0.91 );
-        assertTrue( testMeanError > 0.91 );
+        assertTrue( trainAccuracy >= _trainAccuracy );
+        assertTrue( testAccuracy >= _testAccuracy );
     }
 
 }

--- a/code/core/src/test/java/io/agi/core/ml/supervised/SvmTest.java
+++ b/code/core/src/test/java/io/agi/core/ml/supervised/SvmTest.java
@@ -51,11 +51,13 @@ public class SvmTest {
     private Data _classTruthVectorTest = null;
 
     // Parameters
-    private String trainPath;
-    private String testPath;
-    private int featuresIdxMin;
-    private int featuresIdxMax;
-    private int classTruthIdx;
+    private String _trainPath;
+    private String _testPath;
+    private int _featuresIdxMin;
+    private int _featuresIdxMax;
+    private int _classTruthIdx;
+    private double _trainAccuracy;
+    private double _testAccuracy;
 
     /**
      * Sets up the parameters for the test
@@ -65,13 +67,17 @@ public class SvmTest {
      * @param featuresIdxMin The column ID where features start
      * @param featuresIdxMax The column ID where features end
      * @param classTruthIdx The column ID of the target (y) / class truth
+     * @param trainAccuracy The expected training accuracy for assertion
+     * @param testAccuracy The expected test accuracy for assertion
      */
-    public SvmTest(String trainPath, String testPath, int featuresIdxMin, int featuresIdxMax, int classTruthIdx) {
-        this.trainPath = trainPath;
-        this.testPath = testPath;
-        this.featuresIdxMin = featuresIdxMin;
-        this.featuresIdxMax = featuresIdxMax;
-        this.classTruthIdx = classTruthIdx;
+    public SvmTest(String trainPath, String testPath, int featuresIdxMin, int featuresIdxMax, int classTruthIdx, double trainAccuracy, double testAccuracy) {
+        this._trainPath = trainPath;
+        this._testPath = testPath;
+        this._featuresIdxMin = featuresIdxMin;
+        this._featuresIdxMax = featuresIdxMax;
+        this._classTruthIdx = classTruthIdx;
+        this._trainAccuracy = trainAccuracy;
+        this._testAccuracy = testAccuracy;
     }
 
     /**
@@ -82,9 +88,10 @@ public class SvmTest {
     @Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                {"iris.train.csv", "iris.test.csv", 0, 3, 4},
-                {"spectf.train.csv", "spectf.test.csv", 1, 44, 0},
-                {"skin.train.sample.csv", "skin.test.sample.csv", 0, 2, 3}
+                // trainPath, testPath, featuresIdxMin, featuresIdxMax, classTruthIdx, trainAccuracy, testAccuracy
+                {"iris.train.csv", "iris.test.csv", 0, 3, 4, 1, 0.95},
+                {"spectf.train.csv", "spectf.test.csv", 1, 44, 0, 1, 0.90},
+                {"skin.train.sample.csv", "skin.test.sample.csv", 0, 2, 3, 1, 0.90}
         });
     }
 
@@ -113,13 +120,13 @@ public class SvmTest {
     public void setUp() throws Exception {
 
         // get data from file
-        String filePath = "src/test/resources/" + trainPath;
-        _featuresMatrixTrain = Data2d.createFromCSV( filePath, featuresIdxMin, featuresIdxMax);
-        _classTruthVector = Data2d.createFromCSV( filePath, classTruthIdx, classTruthIdx );
+        String filePath = "src/test/resources/" + _trainPath;
+        _featuresMatrixTrain = Data2d.createFromCSV( filePath, _featuresIdxMin, _featuresIdxMax);
+        _classTruthVector = Data2d.createFromCSV( filePath, _classTruthIdx, _classTruthIdx );
 
-        filePath = "src/test/resources/" + testPath;
-        _featuresMatrixTest = Data2d.createFromCSV( filePath, featuresIdxMin, featuresIdxMax );
-        _classTruthVectorTest = Data2d.createFromCSV( filePath, classTruthIdx, classTruthIdx );
+        filePath = "src/test/resources/" + _testPath;
+        _featuresMatrixTest = Data2d.createFromCSV( filePath, _featuresIdxMin, _featuresIdxMax );
+        _classTruthVectorTest = Data2d.createFromCSV( filePath, _classTruthIdx, _classTruthIdx );
 
         _predictionsVector = new Data( _classTruthVector._dataSize );
         _predictionsVectorTest = new Data( _classTruthVectorTest._dataSize );
@@ -149,7 +156,6 @@ public class SvmTest {
     private void predict() throws Exception {
 
         boolean log = false;
-        float _eps = 0.0000001f;
 
         // Evaluate on training data
         _learner.predict( _featuresMatrixTrain, _predictionsVector );
@@ -159,9 +165,9 @@ public class SvmTest {
 
         if ( log )
         {
-            String features = Data2d.toString( _featuresMatrixTrain );
-            String predictions = Data2d.toString( _predictionsVector );
-            String classTruth = Data2d.toString( _classTruthVector );
+            String features = Data2d.toString( _featuresMatrixTest );
+            String predictions = Data2d.toString( _predictionsVectorTest );
+            String classTruth = Data2d.toString( _classTruthVectorTest );
 
             System.out.println( "Features" );
             System.out.println( features );
@@ -171,29 +177,28 @@ public class SvmTest {
 
             System.out.println( "ClassTruth" );
             System.out.println( classTruth );
-
         }
 
-        // set values to 1 if error, 0 if not
-        _predictionsVector.approxEquals( _classTruthVector, _eps );
-        _predictionsVectorTest.approxEquals( _classTruthVectorTest, _eps );
+        // set values to 1 if correct, 0 if not
+        _predictionsVector.equals( _classTruthVector );
+        _predictionsVectorTest.equals( _classTruthVectorTest );
 
         if ( log ) {
-            String error = Data2d.toString( _predictionsVector );
+            String error = Data2d.toString( _predictionsVectorTest );
             System.out.println( "Error" );
             System.out.println( error );
         }
 
-        // count how many errors - an error is where the diff between prediction and label is greater than eps
-        double trainMeanError = _predictionsVector.mean();
-        double testMeanError = _predictionsVectorTest.mean();
+        // total correct values / total values
+        double trainAccuracy = _predictionsVector.mean();
+        double testAccuracy = _predictionsVectorTest.mean();
 
         System.out.println( "Model = " + _learner.getModelString() );
-        System.out.println( "Training Accuracy = " + trainMeanError * 100 + "%" );
-        System.out.println( "Testing Accuracy = " + testMeanError * 100 + "%" );
+        System.out.println( "Training Accuracy = " + trainAccuracy * 100 + "%" );
+        System.out.println( "Testing Accuracy = " + testAccuracy * 100 + "%" );
 
-        assertTrue( trainMeanError > 0.89 );
-        assertTrue( testMeanError > 0.89 );
+        assertTrue( trainAccuracy >= _trainAccuracy );
+        assertTrue( testAccuracy >= _testAccuracy );
     }
 
 }


### PR DESCRIPTION
**Post-mortem**
The issue was kind of staring at us in the face, but easy to miss with the focus being solely on an implementation or a parameter issue.

The `predict` methods in Logistic Regression and Svm return the actual predicted label, so would be for example `1` or `0` in binary classification. We were getting the right predicted labels, but when outputting the accuracy to the screen we were instead calculating the mean error. The mean error would have been fine if we're actually looking at errors.

Since we were actually getting the predicted class, the `approxEquals` ended up not really working for this case. For example, if classTruth (1) and predicted (1), then `approxEquals` would indicate this is an error by returning `1` since `1-1 < EPS`.

With the SPECTF dataset, this lead to the `meanError` being ~0.95 on the test set but the classification accuracy was actually ~0.60, similar to scikit-learn and liblinear.

**Changes**
- Added a similar method to `FloatArray.approxEquals`, but instead checking if value from `arr1` is equal to the value from `arr2`, then return 1 otherwise return 0.
- Parameterised the "expected" train/test accuracy, so we can specify different assertions for each dataset
- Updated LogisticRegression & Svm tests to use the correct classification accuracy, and used the results from scikit-learn as the expected train/test accuracy for the assertions

**NOTE:** Let me know if the `FloatArray.equals` method should be moved elsewhere, or if we already have something similar that I may have missed.