### PR TITLE
Fix for approxEquals

### DIFF
--- a/code/core/src/main/java/io/agi/core/data/FloatArray.java
+++ b/code/core/src/main/java/io/agi/core/data/FloatArray.java
@@ -1330,23 +1330,8 @@ public class FloatArray {
         int offset = 0;
 
         while( offset < _values.length ) {
-            float diff = _values[ offset ] - v._values[ offset ];
+            float diff = Math.abs(_values[ offset ] - v._values[ offset ]);
             if ( diff < tolerance ) {
-                _values[ offset ] = 1.0f;    // set to 'True'
-            }
-            else {
-                _values[ offset ] = 0.0f;   // set to 'False'
-            }
-            ++offset;
-        }
-    }
-
-    public void equals( FloatArray v ) {
-
-        int offset = 0;
-
-        while( offset < _values.length ) {
-            if ( _values[ offset ] == v._values[ offset ] ) {
                 _values[ offset ] = 1.0f;    // set to 'True'
             }
             else {

--- a/code/core/src/test/java/io/agi/core/ml/supervised/LogisticRegressionTest.java
+++ b/code/core/src/test/java/io/agi/core/ml/supervised/LogisticRegressionTest.java
@@ -155,6 +155,7 @@ public class LogisticRegressionTest {
     private void predict() throws Exception {
 
         boolean log = false;
+        float eps = 0.0000001f;
 
         // Evaluate on training data
         _learner.predict( _featuresMatrixTrain, _predictionsVector );
@@ -178,9 +179,9 @@ public class LogisticRegressionTest {
             System.out.println( classTruth );
         }
 
-        // set values to 1 if correct, 0 if not
-        _predictionsVector.equals( _classTruthVector );
-        _predictionsVectorTest.equals( _classTruthVectorTest );
+        // set values to 1 if error, 0 if not
+        _predictionsVector.approxEquals( _classTruthVector, eps );
+        _predictionsVectorTest.approxEquals( _classTruthVectorTest, eps );
 
         if ( log ) {
             String error = Data2d.toString( _predictionsVectorTest );
@@ -188,16 +189,16 @@ public class LogisticRegressionTest {
             System.out.println( error );
         }
 
-        // total correct values / total values
-        double trainAccuracy = _predictionsVector.mean();
-        double testAccuracy = _predictionsVectorTest.mean();
+        // count how many errors - an error is where the diff between prediction and label is greater than eps
+        double trainMeanError = _predictionsVector.mean();
+        double testMeanError = _predictionsVectorTest.mean();
 
         System.out.println( "Model = " + _learner.getModelString() );
-        System.out.println( "Training Accuracy = " + trainAccuracy * 100 + "%" );
-        System.out.println( "Testing Accuracy = " + testAccuracy * 100 + "%" );
+        System.out.println( "Training Accuracy = " + trainMeanError * 100 + "%" );
+        System.out.println( "Testing Accuracy = " + testMeanError * 100 + "%" );
 
-        assertTrue( trainAccuracy >= _trainAccuracy );
-        assertTrue( testAccuracy >= _testAccuracy );
+        assertTrue( trainMeanError >= _trainAccuracy );
+        assertTrue( testMeanError >= _testAccuracy );
     }
 
 }

--- a/code/core/src/test/java/io/agi/core/ml/supervised/SvmTest.java
+++ b/code/core/src/test/java/io/agi/core/ml/supervised/SvmTest.java
@@ -156,6 +156,7 @@ public class SvmTest {
     private void predict() throws Exception {
 
         boolean log = false;
+        float eps = 0.0000001f;
 
         // Evaluate on training data
         _learner.predict( _featuresMatrixTrain, _predictionsVector );
@@ -179,9 +180,9 @@ public class SvmTest {
             System.out.println( classTruth );
         }
 
-        // set values to 1 if correct, 0 if not
-        _predictionsVector.equals( _classTruthVector );
-        _predictionsVectorTest.equals( _classTruthVectorTest );
+        // set values to 1 if error, 0 if not
+        _predictionsVector.approxEquals( _classTruthVector, eps );
+        _predictionsVectorTest.approxEquals( _classTruthVectorTest, eps );
 
         if ( log ) {
             String error = Data2d.toString( _predictionsVectorTest );
@@ -189,16 +190,16 @@ public class SvmTest {
             System.out.println( error );
         }
 
-        // total correct values / total values
-        double trainAccuracy = _predictionsVector.mean();
-        double testAccuracy = _predictionsVectorTest.mean();
+        // count how many errors - an error is where the diff between prediction and label is greater than eps
+        double trainMeanError = _predictionsVector.mean();
+        double testMeanError = _predictionsVectorTest.mean();
 
         System.out.println( "Model = " + _learner.getModelString() );
-        System.out.println( "Training Accuracy = " + trainAccuracy * 100 + "%" );
-        System.out.println( "Testing Accuracy = " + testAccuracy * 100 + "%" );
+        System.out.println( "Training Accuracy = " + trainMeanError * 100 + "%" );
+        System.out.println( "Testing Accuracy = " + testMeanError * 100 + "%" );
 
-        assertTrue( trainAccuracy >= _trainAccuracy );
-        assertTrue( testAccuracy >= _testAccuracy );
+        assertTrue( trainMeanError >= _trainAccuracy );
+        assertTrue( testMeanError >= _testAccuracy );
     }
 
 }


### PR DESCRIPTION
- Removed the new `equals` method
- Fixed `approxEquals` by using `Math.abs` for calculating the difference
- Updated the unit tests to utilise the fixed `approxEquals` method