### PR TITLE
Calculate and Store Experiment Runtime

### DIFF
--- a/code/core/pom.xml
+++ b/code/core/pom.xml
@@ -24,7 +24,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.agi.core</groupId>
     <artifactId>agief</artifactId>
-    <version>1.0.174(54d12b3)</version>
+    <version>1.0.176(9dc03f6)</version>
     <name>agief</name>
 
     <properties>

--- a/code/core/pom.xml
+++ b/code/core/pom.xml
@@ -24,7 +24,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.agi.core</groupId>
     <artifactId>agief</artifactId>
-    <version>1.0.171(6f18ba3)</version>
+    <version>1.0.174(54d12b3)</version>
     <name>agief</name>
 
     <properties>

--- a/code/core/src/main/java/io/agi/framework/entities/ExperimentEntity.java
+++ b/code/core/src/main/java/io/agi/framework/entities/ExperimentEntity.java
@@ -74,8 +74,8 @@ public class ExperimentEntity extends Entity {
         ExperimentEntityConfig config = ( ExperimentEntityConfig ) _config;
 
         if( config.age == 0 ) {
-            _startTime = System.currentTimeMillis();
-            System.out.println("Start time:" + _startTime);
+            config.startTime = System.currentTimeMillis();
+            PersistenceUtil.SetConfigLong( getName(), "startTime", config.startTime );
             _logger.info( "Experiment: " + getName() + " starting at age: " + _config.age + " t: " + System.currentTimeMillis() );
         }
         _logger.debug( "Experiment: " + getName() + " age: " + _config.age + " terminationAge: " + ( (ExperimentEntityConfig) _config ).terminationAge );
@@ -149,8 +149,7 @@ public class ExperimentEntity extends Entity {
 
         // After all children have finished updating and have flushed
         if( config.terminating ) {
-            config.runTime = System.currentTimeMillis() - _startTime;
-
+            config.runTime = System.currentTimeMillis() - config.startTime;
             _logger.info( "Experiment: " + getName() + " terminated at age: " + _config.age + " t: " + System.currentTimeMillis() );
             _logger.info( "Experiment Run Time: " + config.runTime );
 

--- a/code/core/src/main/java/io/agi/framework/entities/ExperimentEntity.java
+++ b/code/core/src/main/java/io/agi/framework/entities/ExperimentEntity.java
@@ -24,6 +24,7 @@ import io.agi.framework.DataFlags;
 import io.agi.framework.Entity;
 import io.agi.framework.Framework;
 import io.agi.framework.Node;
+import io.agi.framework.persistence.Persistence;
 import io.agi.framework.persistence.PersistenceUtil;
 import io.agi.framework.persistence.models.ModelEntity;
 
@@ -45,6 +46,8 @@ import java.util.Collection;
 public class ExperimentEntity extends Entity {
 
     public static final String ENTITY_TYPE = "experiment";
+
+    private long _startTime;
 
     public ExperimentEntity( ObjectMap om, Node n, ModelEntity model ) {
         super( om, n, model );
@@ -71,6 +74,8 @@ public class ExperimentEntity extends Entity {
         ExperimentEntityConfig config = ( ExperimentEntityConfig ) _config;
 
         if( config.age == 0 ) {
+            _startTime = System.currentTimeMillis();
+            System.out.println("Start time:" + _startTime);
             _logger.info( "Experiment: " + getName() + " starting at age: " + _config.age + " t: " + System.currentTimeMillis() );
         }
         _logger.debug( "Experiment: " + getName() + " age: " + _config.age + " terminationAge: " + ( (ExperimentEntityConfig) _config ).terminationAge );
@@ -144,9 +149,14 @@ public class ExperimentEntity extends Entity {
 
         // After all children have finished updating and have flushed
         if( config.terminating ) {
+            config.runTime = System.currentTimeMillis() - _startTime;
+
             _logger.info( "Experiment: " + getName() + " terminated at age: " + _config.age + " t: " + System.currentTimeMillis() );
+            _logger.info( "Experiment Run Time: " + config.runTime );
+
             config.terminated = true;
             PersistenceUtil.SetConfigBoolean( getName(), "terminated", config.terminated ); // config has already been persisted, so changing it now has no effect.
+            PersistenceUtil.SetConfigLong( getName(), "runTime", config.runTime );
         }
 
         if( ( !config.terminated ) && ( !config.pause ) ) {

--- a/code/core/src/main/java/io/agi/framework/entities/ExperimentEntityConfig.java
+++ b/code/core/src/main/java/io/agi/framework/entities/ExperimentEntityConfig.java
@@ -34,6 +34,7 @@ public class ExperimentEntityConfig extends EntityConfig {
     public String terminationEntityName;
     public String terminationConfigPath;
     public int terminationAge = -1; // if negative, then never terminates unless via termination condition.
+    public long runTime = 0;
 
     public String reportingEntityName;
     public String reportingEntityConfigPath;

--- a/code/core/src/main/java/io/agi/framework/entities/ExperimentEntityConfig.java
+++ b/code/core/src/main/java/io/agi/framework/entities/ExperimentEntityConfig.java
@@ -34,6 +34,7 @@ public class ExperimentEntityConfig extends EntityConfig {
     public String terminationEntityName;
     public String terminationConfigPath;
     public int terminationAge = -1; // if negative, then never terminates unless via termination condition.
+    public long startTime = 0;
     public long runTime = 0;
 
     public String reportingEntityName;

--- a/code/core/src/main/java/io/agi/framework/persistence/PersistenceUtil.java
+++ b/code/core/src/main/java/io/agi/framework/persistence/PersistenceUtil.java
@@ -251,6 +251,46 @@ public class PersistenceUtil {
         persistence.persistEntity( modelEntity );
     }
 
+    public static void SetConfigLong( String entityName, String configPath, Long value ) {
+
+        _logger.debug( "Set config of: " + entityName + " path: " + configPath + " value: " + value );
+
+        Persistence persistence = Node.NodeInstance().getPersistence();
+        ModelEntity modelEntity = persistence.getEntity( entityName );
+        JsonParser parser = new JsonParser();
+        JsonObject root = parser.parse( modelEntity.config ).getAsJsonObject();
+
+        // navigate to the nested property
+        // N.B. String.split : http://stackoverflow.com/questions/3481828/how-to-split-a-string-in-java
+        JsonObject parent = root;
+        String[] pathParts = configPath.split( "[.]" );
+        int index = 0;
+        int maxIndex = pathParts.length - 1; // NOTE: one before the one we're looking for
+        String part = null;
+//        if( pathParts.length < 2 ) { // i.e. 0 or 1
+//            part = configPath;
+//        }
+
+        while( index < maxIndex ) {
+            part = pathParts[ index ];
+            JsonElement child = parent.get( part );
+
+            ++index;
+
+            parent = ( JsonObject ) child;
+        }
+
+        part = pathParts[ index ];
+
+        // replace the property:
+        parent.remove( part );
+        parent.addProperty( part, value );
+
+        // re-serialize the whole thing
+        modelEntity.config = root.toString();//getAsString();
+        persistence.persistEntity( modelEntity );
+    }
+
     /**
      * Allows a single config property to be obtained.
      *


### PR DESCRIPTION
**Changes**
- Added a `setConfigLong` method to store `System.currentTimeMillis()` in Entity configs
- Defined the `startTime` and `runTime` parameters in the `ExperimentEntityConfig` class
- Calculating and storing the start time when `config.age == 0`
- Calculating the time difference and storing run time when `config.terminating == true`

Counterpart PR: https://github.com/ProjectAGI/run-framework/pull/18